### PR TITLE
refactor: 소셜로그인 추가로 인해 user 관련 api 리팩토링

### DIFF
--- a/backend/text-me/src/main/java/gifterz/textme/domain/letter/controller/LetterController.java
+++ b/backend/text-me/src/main/java/gifterz/textme/domain/letter/controller/LetterController.java
@@ -27,9 +27,7 @@ public class LetterController {
 
     @GetMapping("/members/{id}")
     public ResponseEntity<List<AllLetterResponse>> findLetters(@PathVariable("id") final String id) {
-        String decryptedId = aesUtils.decryption(id);
-        Long decryptedUserId = Long.valueOf(decryptedId);
-        List<AllLetterResponse> letterResponses = letterService.findLettersByUserId(decryptedUserId);
+        List<AllLetterResponse> letterResponses = letterService.findLettersByUserId(id);
         return ResponseEntity.ok().body(letterResponses);
     }
 

--- a/backend/text-me/src/main/java/gifterz/textme/domain/oauth/entity/OauthMember.java
+++ b/backend/text-me/src/main/java/gifterz/textme/domain/oauth/entity/OauthMember.java
@@ -34,4 +34,8 @@ public class OauthMember extends BaseEntity {
         this.email = email;
         this.nickname = nickname;
     }
+
+    public void updateName(String name) {
+        this.nickname = name;
+    }
 }

--- a/backend/text-me/src/main/java/gifterz/textme/domain/oauth/repository/OauthMemberRepository.java
+++ b/backend/text-me/src/main/java/gifterz/textme/domain/oauth/repository/OauthMemberRepository.java
@@ -2,6 +2,7 @@ package gifterz.textme.domain.oauth.repository;
 
 import gifterz.textme.domain.oauth.entity.OauthId;
 import gifterz.textme.domain.oauth.entity.OauthMember;
+import gifterz.textme.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,4 +12,7 @@ import java.util.Optional;
 public interface OauthMemberRepository extends JpaRepository<OauthMember, Long> {
 
     Optional<OauthMember> findByOauthId(OauthId oauthId);
+
+    Optional<OauthMember> findByEmail(String email);
+
 }

--- a/backend/text-me/src/main/java/gifterz/textme/domain/oauth/service/OauthService.java
+++ b/backend/text-me/src/main/java/gifterz/textme/domain/oauth/service/OauthService.java
@@ -47,7 +47,7 @@ public class OauthService {
     }
 
     private String encryptUserId(OauthMember user) {
-        String userId = String.valueOf(user.getId());
-        return aesUtils.encryption(userId);
+        String userEmail = String.valueOf(user.getEmail());
+        return aesUtils.encrypt(userEmail);
     }
 }

--- a/backend/text-me/src/main/java/gifterz/textme/domain/security/service/AesUtils.java
+++ b/backend/text-me/src/main/java/gifterz/textme/domain/security/service/AesUtils.java
@@ -12,7 +12,7 @@ public class AesUtils {
 
     private final String secretKey = "3^mdfo9iu4alkj";
 
-    public String encryption(String text) {
+    public String encrypt(String plaintext) {
         try {
             Cipher cipher = Cipher.getInstance("AES");
 
@@ -25,13 +25,13 @@ public class AesUtils {
 
             cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key, "AES"));
 
-            return new String(Hex.encodeHex(cipher.doFinal(text.getBytes(StandardCharsets.UTF_8)))).toUpperCase();
+            return new String(Hex.encodeHex(cipher.doFinal(plaintext.getBytes(StandardCharsets.UTF_8)))).toUpperCase();
         } catch(Exception e) {
-            return text;
+            return plaintext;
         }
     }
 
-    public String decryption(String encryptedText) {
+    public String decrypt(String encryptedText) {
         try {
             Cipher cipher = Cipher.getInstance("AES");
 

--- a/backend/text-me/src/main/java/gifterz/textme/domain/security/service/RefreshTokenService.java
+++ b/backend/text-me/src/main/java/gifterz/textme/domain/security/service/RefreshTokenService.java
@@ -1,9 +1,12 @@
 package gifterz.textme.domain.security.service;
 
+import gifterz.textme.domain.oauth.entity.OauthMember;
+import gifterz.textme.domain.oauth.repository.OauthMemberRepository;
 import gifterz.textme.domain.security.entity.RefreshToken;
 import gifterz.textme.domain.security.jwt.JwtUtils;
 import gifterz.textme.domain.security.repository.RefreshTokenRepository;
 import gifterz.textme.domain.user.dto.response.TokenRefreshResponse;
+import gifterz.textme.domain.user.dto.response.UserResponse;
 import gifterz.textme.domain.user.entity.User;
 import gifterz.textme.domain.user.exception.TokenRefreshException;
 import gifterz.textme.domain.user.exception.UserNotFoundException;
@@ -24,6 +27,7 @@ public class RefreshTokenService {
     private Long refreshTokenDurationMs;
     private final RefreshTokenRepository refreshTokenRepository;
     private final UserRepository userRepository;
+    private final OauthMemberRepository oauthMemberRepository;
     private final JwtUtils jwtUtils;
 
     public Optional<RefreshToken> findByAccessToken(String token) {
@@ -49,18 +53,31 @@ public class RefreshTokenService {
     }
 
     public TokenRefreshResponse refreshJwtToken(String email, String token) {
-        Optional<User> userExist = userRepository.findByEmail(email);
-        if (userExist.isEmpty()) {
-            throw new UserNotFoundException();
+        Optional<User> userExists = userRepository.findByEmail(email);
+        if (userExists.isPresent()) {
+            Optional<RefreshToken> refreshTokenExist = findByAccessToken(token);
+            if (refreshTokenExist.isEmpty()) {
+                throw new TokenRefreshException(token,
+                        "refreshToken이 DB에 존재하지 않습니다.");
+            }
+            RefreshToken refreshToken = verifyExpiration(refreshTokenExist.get());
+            User user = userExists.get();
+            String newToken = jwtUtils.generateJwtToken(user);
+            return new TokenRefreshResponse(newToken, refreshToken.getRefreshToken(), refreshToken.getCreatedAt());
         }
-        User user = userExist.get();
-        Optional<RefreshToken> refreshTokenExist = findByAccessToken(token);
-        if (refreshTokenExist.isEmpty()) {
-            throw new TokenRefreshException(token,
-                    "refreshToken이 DB에 존재하지 않습니다.");
+
+        Optional<OauthMember> oauthMemberExists = oauthMemberRepository.findByEmail(email);
+        if (oauthMemberExists.isPresent()) {
+            Optional<RefreshToken> refreshTokenExist = findByAccessToken(token);
+            if (refreshTokenExist.isEmpty()) {
+                throw new TokenRefreshException(token,
+                        "refreshToken이 DB에 존재하지 않습니다.");
+            }
+            RefreshToken refreshToken = verifyExpiration(refreshTokenExist.get());
+            OauthMember oauthMember = oauthMemberExists.get();
+            String newToken = jwtUtils.generateJwtToken(oauthMember);
+            return new TokenRefreshResponse(newToken, refreshToken.getRefreshToken(), refreshToken.getCreatedAt());
         }
-        RefreshToken refreshToken = verifyExpiration(refreshTokenExist.get());
-        String newToken = jwtUtils.generateJwtToken(user);
-        return new TokenRefreshResponse(newToken, refreshToken.getRefreshToken(), refreshToken.getCreatedAt());
+        throw new UserNotFoundException();
     }
 }

--- a/backend/text-me/src/main/java/gifterz/textme/domain/user/controller/UserController.java
+++ b/backend/text-me/src/main/java/gifterz/textme/domain/user/controller/UserController.java
@@ -73,9 +73,7 @@ public class UserController {
 
     @GetMapping("/find/{id}")
     public ResponseEntity<UserResponse> findUserInfoByUserId(@PathVariable("id") final String id) {
-        String decryptedId = aesUtils.decryption(id);
-        Long decryptedUserId = Long.valueOf(decryptedId);
-        UserResponse userResponse = userService.findUserInfoByUserId(decryptedUserId);
+        UserResponse userResponse = userService.findUserInfoByUserId(id);
         return ResponseEntity.ok().body(userResponse);
     }
 }

--- a/backend/text-me/src/main/java/gifterz/textme/domain/user/entity/User.java
+++ b/backend/text-me/src/main/java/gifterz/textme/domain/user/entity/User.java
@@ -32,11 +32,15 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private String password;
 
-    public User(String name, String email, String password) {
+    private User(String name, String email, String password) {
         super(StatusType.ACTIVATE.getStatus());
         this.name = name;
         this.email = email;
         this.password = password;
+    }
+
+    public static User of(String name, String email, String password) {
+        return new User(name, email, password);
     }
 
     public void setPassword(String encodedPassword) {

--- a/backend/text-me/src/main/java/gifterz/textme/domain/user/service/UserService.java
+++ b/backend/text-me/src/main/java/gifterz/textme/domain/user/service/UserService.java
@@ -119,9 +119,20 @@ public class UserService {
     }
 
     public UserResponse findUserInfoByEmail(String email) {
-        User user = userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
-        String encryptedUserId = encryptUserEmail(user);
-        return new UserResponse(encryptedUserId, user.getName(), user.getEmail());
+        Optional<User> userExists = userRepository.findByEmail(email);
+        if (userExists.isPresent()) {
+            User user = userExists.get();
+            String encryptedText = encryptUserEmail(user);
+            return new UserResponse(encryptedText, user.getName(), user.getEmail());
+        }
+
+        Optional<OauthMember> oauthMemberExists = oauthMemberRepository.findByEmail(email);
+        if (oauthMemberExists.isPresent()) {
+            OauthMember oauthMember = oauthMemberExists.get();
+            String encryptedUserId = encryptUserEmail(oauthMember);
+            return new UserResponse(encryptedUserId, oauthMember.getNickname(), oauthMember.getEmail());
+        }
+        throw new UserNotFoundException();
     }
 
     public UserResponse findUserInfoByUserId(String encryptedId) {

--- a/backend/text-me/src/main/java/gifterz/textme/domain/user/service/UserService.java
+++ b/backend/text-me/src/main/java/gifterz/textme/domain/user/service/UserService.java
@@ -137,8 +137,7 @@ public class UserService {
 
     public UserResponse findUserInfoByUserId(String encryptedId) {
         String userEmail = aesUtils.decrypt(encryptedId);
-        User user = userRepository.findByEmail(userEmail).orElseThrow(UserNotFoundException::new);
-        return new UserResponse(encryptedId, user.getName(), user.getEmail());
+        return findUserInfoByEmail(userEmail);
     }
 
     private String encryptUserEmail(User user) {

--- a/backend/text-me/src/main/java/gifterz/textme/domain/user/service/UserService.java
+++ b/backend/text-me/src/main/java/gifterz/textme/domain/user/service/UserService.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -68,7 +69,8 @@ public class UserService {
         User user = userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
         Authentication authentication = authenticationManager
                 .authenticate(new UsernamePasswordAuthenticationToken(email, password));
-        SecurityContextHolder.getContext().setAuthentication(authentication);
+        SecurityContext securityContext = SecurityContextHolder.getContext();
+        securityContext.setAuthentication(authentication);
 
         String accessToken = jwtUtils.generateJwtToken(user);
         RefreshToken refreshToken = refreshTokenService.createRefreshToken(accessToken);


### PR DESCRIPTION
작업내용
---
- 회원가입 api 리팩토링
- 일반 로그인 api 디미터 법칙 적용
- 사용자 정보 조회 api 리팩토링
- 사용자 이름 업데이트 api 리팩토링
- 소셜로그인 추가로 인해 id 중복 가능성으로 기존 url에 노출되던 데이터를 사용자 id 사용 대신 email 데이터 사용
- 이메일 사용한 사용자 정보 조회 api 리팩토링
- 사용자 ID 사용한 정보 조회 api 리팩토링
- Refresh토큰 재발급 api 리팩토링
- 소셜로그인 사용자 이름 변경 로직 추가